### PR TITLE
Hyperlink DOIs against preferred resolver

### DIFF
--- a/js/static_table.js
+++ b/js/static_table.js
@@ -109,7 +109,7 @@ function createTable(structureJson, containerSelector) {
       const text = d.date;
 
       if (d.doi) {
-        return text + " <a href='http://dx.doi.org/" + d.doi + "' target='_new'>" +
+        return text + " <a href='https://doi.org/" + d.doi + "' target='_new'>" +
           "<i class=\"fas fa-external-link-alt\"></i>" +
           "</a>";
       } else {


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates the code that generates new DOI links.

Cheers!


PS: The following code might need to be upgraded wit a reg-ex, to catch such "new" DOI links: https://github.com/getcontacts/atlas/blob/7bd48e02d669312321c479c7452d66acbb580f2f/static_data/gpcr/reformat_gpcrdbdump.py#L38-L42

Maybe as in [DOAJ/#1505/files#diff](https://github.com/DOAJ/doaj/pull/1505/files#diff-bfc3d2cf37e42b5141f386e8f61e8a02R24)? I'm not using Python productively, so I'm not sure how best to `grep` around it.